### PR TITLE
Add missing content type.

### DIFF
--- a/library/src/main/java/com/meisolsson/githubsdk/model/ContentType.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/ContentType.java
@@ -20,5 +20,6 @@ import com.squareup.moshi.Json;
 
 public enum ContentType {
     @Json(name = "dir") Directory,
-    @Json(name = "file") File
+    @Json(name = "file") File,
+    @Json(name = "symlink") Symlink
 }


### PR DESCRIPTION
Saw this exception: `Caused by com.squareup.moshi.JsonDataException Expected one of [dir, file] but was symlink at path $.items[17].type`