### PR TITLE
One needs to pass milestone number when editing issues, not id.

### DIFF
--- a/library/src/main/java/com/meisolsson/githubsdk/model/request/issue/IssueRequest.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/request/issue/IssueRequest.java
@@ -39,7 +39,7 @@ public abstract class IssueRequest implements Parcelable {
     public abstract String body();
 
     @Nullable
-    public abstract Long milestone();
+    public abstract Integer milestone();
 
     @Nullable
     public abstract List<String> labels();
@@ -63,7 +63,7 @@ public abstract class IssueRequest implements Parcelable {
 
         public abstract Builder body(String body);
 
-        public abstract Builder milestone(Long milestone);
+        public abstract Builder milestone(Integer milestone);
 
         public abstract Builder labels(List<String> labels);
 


### PR DESCRIPTION
I wonder whether this should be made clearer in the method names?